### PR TITLE
calculate adler32 save to xattr in XrdCksData format

### DIFF
--- a/bin.src/register-release.dp1.py
+++ b/bin.src/register-release.dp1.py
@@ -1,5 +1,3 @@
-# register data in DP1 butler to Rucio
-#
 import argparse
 import hashlib
 import logging
@@ -14,6 +12,7 @@ from lsst.daf.butler import Butler, DatasetRef
 from lsst.daf.butler.cli.cliLog import CliLog
 from rucio.client.didclient import DIDClient
 from rucio.client.replicaclient import ReplicaClient
+from xrdadler32 import xrd_get_size_and_adler32
 
 
 def parse_args():
@@ -92,23 +91,14 @@ def retry(retry_label: str, func: Any, *args, **kwargs) -> Any:
             retries += 1
             logger.warning(f"{retry_label} retry {retries}: {e}")
             time.sleep(random.uniform(2, 10))
+            exit(1)
     if retries >= max_retries:
         raise RuntimeError("Unable to communicate with database")
 
 
 def getchecksum(path):
-    size = 0
-    md5 = hashlib.md5()
-    adler32 = zlib.adler32(b"")
-    if not config.dry_run:
-        with open(path, "rb") as fd:
-            while buf := fd.read(10 * 1024 * 1024):
-                size += len(buf)
-                md5.update(buf)
-                adler32 = zlib.adler32(buf, adler32)
-    md5_digest = md5.hexdigest()
-    adler32_digest = f"{adler32:08x}"
-    return size, adler32_digest, md5_digest
+    size, adler32_digest = xrd_get_size_and_adler32(path)
+    return size, adler32_digest
 
 
 dsmap = dict()
@@ -208,7 +198,6 @@ for i, dstype in enumerate(dataset_type_list):
     logger.info(f"Handling dataset type {dstype}: {i}/{len(dataset_type_list)}")
 
     files = []
-    # pathmap maps rel_path to os path
     pathmap = {}
     ref_list = sorted(
         retry(
@@ -263,12 +252,24 @@ for i, dstype in enumerate(dataset_type_list):
         # Define the Rucio DID for the file.
         did = dict(
             name=rel_path,
+            #bytes=-1,
+            #md5="00000000000000000000000000000000",
+            #adler32="00000000",
             scope=config.scope,
         )
 
         # Do batched addition of replicas.
         files.append(did)
-        if len(files) >= 500:
+
+        # Do batched addition of files to Datasets.
+        n_files[rucio_dataset] += 1
+        rucio_datasets[rucio_dataset].append(did)
+
+        # when (len(ref_list) - j) <= config.njobs, this one is the last of the
+        # current "for j, ref in enumerate(ref_list):" iteration for this
+        # config.njobs and config.jobnum combination. So everything much be pushed
+        # to Rucio
+        if len(files) >= 500 or (len(ref_list) - j) <= config.njobs:
             if not config.dry_run:
                 present = replica_client.list_replicas(
                     files,
@@ -277,7 +278,7 @@ for i, dstype in enumerate(dataset_type_list):
                 existing_names = {replica["name"] for replica in present}
                 files = [did for did in files if did["name"] not in existing_names]
                 for did in files:
-                    did["bytes"], did["adler32"], did["md5"] = getchecksum(pathmap[did["name"]])
+                    did["bytes"], did["adler32"] = getchecksum(pathmap[did["name"]])
                 if len(files) > 0:
                     retry(
                         "add replicas",
@@ -285,33 +286,34 @@ for i, dstype in enumerate(dataset_type_list):
                         rse=config.rse,
                         files=files,
                     )
+            logger.info(f"add replica : {len(files)} dstype {dstype.name}")
             files = []
             pathmap = {}
 
-        # Do batched addition of files to Datasets.
-        n_files[rucio_dataset] += 1
-        rucio_datasets[rucio_dataset].append(did)
-        if len(rucio_datasets[rucio_dataset]) >= 500:
-            if not config.dry_run:
-                present = did_client.list_content(
-                    scope=config.scope, name=rucio_dataset
-                )
-                existing_names = {did["name"] for did in present}
-                needed = [
-                    did
-                    for did in rucio_datasets[rucio_dataset]
-                    if did["name"] not in existing_names
-                ]
-                if len(needed) > 0:
-                    retry(
-                        f"add files to {rucio_dataset}",
-                        did_client.add_files_to_dataset,
-                        scope=config.scope,
-                        name=rucio_dataset,
-                        files=needed,
-                        rse=config.rse,
+            # Add all pending DIDs to their respective datasets
+            for rucio_dataset_i in rucio_datasets:
+                if not config.dry_run and (len(rucio_datasets[rucio_dataset_i]) > 500 or
+                                           (len(ref_list) - j) <= config.njobs) :
+                    present = did_client.list_content(
+                        scope=config.scope, name=rucio_dataset_i
                     )
-            rucio_datasets[rucio_dataset] = []
+                    existing_names = {did["name"] for did in present}
+                    needed = [
+                        did
+                        for did in rucio_datasets[rucio_dataset_i]
+                        if did["name"] not in existing_names
+                    ]
+                    if len(needed) > 0:
+                        retry(
+                            f"add files to {rucio_dataset}",
+                            did_client.add_files_to_dataset,
+                            scope=config.scope,
+                            name=rucio_dataset_i,
+                            files=needed,
+                            rse=config.rse,
+                        )
+                    logger.info(f"attach to dataset : {len(needed)} dstype {dstype.name}")
+                    rucio_datasets[rucio_dataset_i] = []
 
     # Finish any partial batches.
     if files:
@@ -323,9 +325,10 @@ for i, dstype in enumerate(dataset_type_list):
             existing_names = {replica["name"] for replica in present}
             files = [did for did in files if did["name"] not in existing_names]
             for did in files:
-                did["bytes"], did["adler32"], did["md5"] = getchecksum(pathmap[did["name"]])
+                did["bytes"], did["adler32"] = getchecksum(pathmap[did["name"]])
             if len(files) > 0:
                 retry("add replicas", replica_client.add_replicas, rse=config.rse, files=files)
+        logger.info(f"add replica: {len(files)}")
         files = []
 
     for rucio_dataset_i in rucio_datasets:
@@ -347,6 +350,7 @@ for i, dstype in enumerate(dataset_type_list):
                         files=needed,
                         rse=config.rse,
                     )
+            logger.info(f"attach to dataset : {len(needed)}")
             rucio_datasets[rucio_dataset_i] = []
 
 for rucio_dataset in rucio_datasets:

--- a/bin.src/register-release.dp1.py
+++ b/bin.src/register-release.dp1.py
@@ -1,9 +1,7 @@
 import argparse
-import hashlib
 import logging
 import random
 import time
-import zlib
 from typing import Any
 
 import rucio.common.exception
@@ -250,9 +248,9 @@ for i, dstype in enumerate(dataset_type_list):
         # Define the Rucio DID for the file.
         did = dict(
             name=rel_path,
-            #bytes=-1,
-            #md5="00000000000000000000000000000000",
-            #adler32="00000000",
+            # bytes=-1,
+            # md5="00000000000000000000000000000000",
+            # adler32="00000000",
             scope=config.scope,
         )
 
@@ -265,8 +263,8 @@ for i, dstype in enumerate(dataset_type_list):
 
         # when (len(ref_list) - j) <= config.njobs, this one is the last of the
         # current "for j, ref in enumerate(ref_list):" iteration for this
-        # config.njobs and config.jobnum combination. So everything much be pushed
-        # to Rucio
+        # config.njobs and config.jobnum combination. So everything much be
+        # pushed to Rucio
         if len(files) >= 500 or (len(ref_list) - j) <= config.njobs:
             if not config.dry_run:
                 present = replica_client.list_replicas(
@@ -289,9 +287,10 @@ for i, dstype in enumerate(dataset_type_list):
             pathmap = {}
 
             # Add all pending DIDs to their respective datasets
+            if config.dry_run:
+                continue
             for rucio_dataset_i in rucio_datasets:
-                if not config.dry_run and (len(rucio_datasets[rucio_dataset_i]) > 500 or
-                                           (len(ref_list) - j) <= config.njobs) :
+                if len(rucio_datasets[rucio_dataset_i]) > 500 or (len(ref_list) - j) <= config.njobs:
                     present = did_client.list_content(
                         scope=config.scope, name=rucio_dataset_i
                     )

--- a/bin.src/register-release.dp1.py
+++ b/bin.src/register-release.dp1.py
@@ -180,7 +180,6 @@ butler = Butler(config.repo)
 root = butler._datastore.root
 
 n_files = dict()
-n_bytes = dict()
 rucio_datasets = dict()
 
 dataset_type_list = sorted(
@@ -247,7 +246,6 @@ for i, dstype in enumerate(dataset_type_list):
                     pass
             rucio_datasets[rucio_dataset] = []
             n_files[rucio_dataset] = 0
-            n_bytes[rucio_dataset] = 0
 
         # Define the Rucio DID for the file.
         did = dict(
@@ -314,44 +312,6 @@ for i, dstype in enumerate(dataset_type_list):
                         )
                     logger.info(f"attach to dataset : {len(needed)} dstype {dstype.name}")
                     rucio_datasets[rucio_dataset_i] = []
-
-    # Finish any partial batches.
-    if files:
-        if not config.dry_run:
-            present = replica_client.list_replicas(
-                files,
-                rse_expression=config.rse,
-            )
-            existing_names = {replica["name"] for replica in present}
-            files = [did for did in files if did["name"] not in existing_names]
-            for did in files:
-                did["bytes"], did["adler32"] = getchecksum(pathmap[did["name"]])
-            if len(files) > 0:
-                retry("add replicas", replica_client.add_replicas, rse=config.rse, files=files)
-        logger.info(f"add replica: {len(files)}")
-        files = []
-
-    for rucio_dataset_i in rucio_datasets:
-        if rucio_datasets[rucio_dataset_i]:
-            if not config.dry_run:
-                present = did_client.list_content(scope=config.scope, name=rucio_dataset_i)
-                existing_names = {did["name"] for did in present}
-                needed = [
-                    did
-                    for did in rucio_datasets[rucio_dataset_i]
-                    if did["name"] not in existing_names
-                ]
-                if len(needed) > 0:
-                    retry(
-                        f"add files to {rucio_dataset_i}",
-                        did_client.add_files_to_dataset,
-                        scope=config.scope,
-                        name=rucio_dataset_i,
-                        files=needed,
-                        rse=config.rse,
-                    )
-            logger.info(f"attach to dataset : {len(needed)}")
-            rucio_datasets[rucio_dataset_i] = []
 
 for rucio_dataset in rucio_datasets:
     logger.info(f"{rucio_dataset} has {n_files[rucio_dataset]} files")

--- a/bin.src/xrdadler32.py
+++ b/bin.src/xrdadler32.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Return the size (bytes) and adler32 checksum of a file.
+
+Caching logic (via xattr "user.XrdCks.adler32"):
+  1. xattr present AND fmTime matches file mtime  -> use cached checksum
+  2. xattr present BUT fmTime doesn't match       -> recompute + update xattr
+  3. xattr absent                                 -> compute + write xattr
+
+XrdCksData struct layout (network / big-endian byte order):
+
+    Offset  Size  Field
+    ------  ----  -----
+     0      16    Name     - checksum algorithm name (null-padded ASCII)
+    16       8    fmTime   - file modification time (int64, Unix seconds)
+    24       4    bufSize  - length of the checksum value (int32)
+    28       2    Flags    - status flags (uint16)
+    30       2    Length   - number of valid bytes in csVal (uint16)
+    32      32    csVal    - raw checksum bytes, zero-padded to 32 bytes
+    64      32    padding  - reserved / zero
+
+Total struct size: 96 bytes.
+"""
+
+import os
+import struct
+import sys
+import zlib
+from datetime import datetime, timezone
+from enum import Enum
+
+
+# ── constants ──────────────────────────────────────────────────────────────────
+XATTR_NAME  = "user.XrdCks.adler32"
+ALGO_NAME   = b"adler32"
+CS_VAL_SIZE = 32
+STRUCT_SIZE = 96
+HEADER_FMT  = ">16s q i H H"   # Name(16) fmTime(8) bufSize(4) Flags(2) Length(2)
+HEADER_SIZE = struct.calcsize(HEADER_FMT)   # = 32
+CHUNK_SIZE  = 1 << 20           # 1 MiB read buffer
+
+
+# ── checksum ───────────────────────────────────────────────────────────────────
+
+def compute_adler32(path: str) -> int:
+    """Stream-compute the adler32 checksum of `path`."""
+    checksum = 1
+    with open(path, "rb") as fh:
+        while chunk := fh.read(CHUNK_SIZE):
+            checksum = zlib.adler32(chunk, checksum)
+    return checksum & 0xFFFFFFFF
+
+
+# ── struct packing / unpacking ─────────────────────────────────────────────────
+
+def pack_xrdcks(checksum: int, fm_time: int) -> bytes:
+    """Serialise an XrdCksData record for an adler32 checksum (96 bytes)."""
+    name_field = ALGO_NAME.ljust(16, b"\x00")
+    cs_length  = 4
+    header     = struct.pack(HEADER_FMT, name_field, fm_time, cs_length, 0, cs_length)
+    cs_field   = struct.pack(">I", checksum).ljust(CS_VAL_SIZE, b"\x00")
+    payload    = header + cs_field
+    payload   += b"\x00" * (STRUCT_SIZE - len(payload))
+    return payload
+
+
+def unpack_xrdcks(raw: bytes) -> tuple[int, int]:
+    """
+    Deserialise a raw XrdCksData byte string.
+
+    Returns:
+        (checksum, fm_time) where checksum is a 32-bit int and
+        fm_time is a Unix timestamp int.
+
+    Raises:
+        ValueError if the data is malformed or the algorithm is not adler32.
+    """
+    if len(raw) < HEADER_SIZE:
+        raise ValueError(f"xattr too short: {len(raw)} bytes")
+
+    name_bytes, fm_time, _buf_size, _flags, length = struct.unpack_from(HEADER_FMT, raw, 0)
+    name = name_bytes.split(b"\x00", 1)[0].decode("ascii")
+
+    if name != "adler32":
+        raise ValueError(f"unexpected algorithm in xattr: '{name}'")
+    if length == 0 or HEADER_SIZE + length > len(raw):
+        raise ValueError(f"invalid checksum length field: {length}")
+
+    cs_bytes = raw[HEADER_SIZE : HEADER_SIZE + length]
+    checksum = int.from_bytes(cs_bytes, "big")
+    return checksum, fm_time
+
+
+# ── xattr I/O ──────────────────────────────────────────────────────────────────
+
+def read_xattr(path: str) -> bytes | None:
+    """Return raw xattr bytes, or None if the attribute doesn't exist."""
+    try:
+        return os.getxattr(path, XATTR_NAME)
+    except OSError as exc:
+        if exc.errno in (61, 95, 2):  # ENODATA / EOPNOTSUPP / ENOENT
+            return None
+        raise
+
+
+def write_xattr(path: str, raw: bytes) -> None:
+    """Write raw bytes to the xattr, with a helpful error for unsupported fs."""
+    try:
+        os.setxattr(path, XATTR_NAME, raw)
+    except OSError as exc:
+        pass
+
+
+# ── main logic ─────────────────────────────────────────────────────────────────
+
+def xrd_get_size_and_adler32(path: str) -> tuple[int, int]:
+    """
+    Return (size_bytes, adler32_checksum(hex)) for `path`.
+
+    Reads from the xattr cache when possible; recomputes and updates
+    the cache when the file has been modified or the xattr is absent.
+    """
+    stat    = os.stat(path)
+    size    = stat.st_size
+    mtime   = int(stat.st_mtime)
+
+    # ── try to read cached value ───────────────────────────────────────────────
+    raw = read_xattr(path)
+    if raw is not None:
+        try:
+            checksum, fm_time = unpack_xrdcks(raw)
+            if fm_time == mtime:
+                return size, f'{checksum:08x}'
+        except ValueError:
+           pass   # treat corrupt xattr as missing
+
+    # ── (re)compute and cache ──────────────────────────────────────────────────
+    checksum = compute_adler32(path)
+    write_xattr(path, pack_xrdcks(checksum, mtime))
+    return size, f'{checksum:08x}'
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <file>", file=sys.stderr)
+        sys.exit(1)
+
+    path = sys.argv[1]
+
+    if not os.path.isfile(path):
+        print(f"Error: '{path}' is not a regular file", file=sys.stderr)
+        sys.exit(1)
+
+    size, checksum = xrd_get_size_and_adler32(path)
+
+    print(f'{checksum} {path}')
+
+
+if __name__ == "__main__":
+    main()

--- a/bin.src/xrdadler32.py
+++ b/bin.src/xrdadler32.py
@@ -26,21 +26,19 @@ import os
 import struct
 import sys
 import zlib
-from datetime import datetime, timezone
-from enum import Enum
 
 
-# ── constants ──────────────────────────────────────────────────────────────────
-XATTR_NAME  = "user.XrdCks.adler32"
-ALGO_NAME   = b"adler32"
+# ── constants ─────────────────────────────────────────────────────────
+XATTR_NAME = "user.XrdCks.adler32"
+ALGO_NAME = b"adler32"
 CS_VAL_SIZE = 32
 STRUCT_SIZE = 96
-HEADER_FMT  = ">16s q i H H"   # Name(16) fmTime(8) bufSize(4) Flags(2) Length(2)
+HEADER_FMT = ">16s q i H H"   # Name(16) fmTime(8) bufSize(4) Flags(2) Length(2)
 HEADER_SIZE = struct.calcsize(HEADER_FMT)   # = 32
-CHUNK_SIZE  = 1 << 20           # 1 MiB read buffer
+CHUNK_SIZE = 1 << 20           # 1 MiB read buffer
 
 
-# ── checksum ───────────────────────────────────────────────────────────────────
+# ── checksum ──────────────────────────────────────────────────────────
 
 def compute_adler32(path: str) -> int:
     """Stream-compute the adler32 checksum of `path`."""
@@ -51,16 +49,16 @@ def compute_adler32(path: str) -> int:
     return checksum & 0xFFFFFFFF
 
 
-# ── struct packing / unpacking ─────────────────────────────────────────────────
+# ── struct packing / unpacking ────────────────────────────────────────
 
 def pack_xrdcks(checksum: int, fm_time: int) -> bytes:
     """Serialise an XrdCksData record for an adler32 checksum (96 bytes)."""
     name_field = ALGO_NAME.ljust(16, b"\x00")
-    cs_length  = 4
-    header     = struct.pack(HEADER_FMT, name_field, fm_time, cs_length, 0, cs_length)
-    cs_field   = struct.pack(">I", checksum).ljust(CS_VAL_SIZE, b"\x00")
-    payload    = header + cs_field
-    payload   += b"\x00" * (STRUCT_SIZE - len(payload))
+    cs_length = 4
+    header = struct.pack(HEADER_FMT, name_field, fm_time, cs_length, 0, cs_length)
+    cs_field = struct.pack(">I", checksum).ljust(CS_VAL_SIZE, b"\x00")
+    payload = header + cs_field
+    payload += b"\x00" * (STRUCT_SIZE - len(payload))
     return payload
 
 
@@ -86,12 +84,12 @@ def unpack_xrdcks(raw: bytes) -> tuple[int, int]:
     if length == 0 or HEADER_SIZE + length > len(raw):
         raise ValueError(f"invalid checksum length field: {length}")
 
-    cs_bytes = raw[HEADER_SIZE : HEADER_SIZE + length]
+    cs_bytes = raw[HEADER_SIZE:HEADER_SIZE + length]
     checksum = int.from_bytes(cs_bytes, "big")
     return checksum, fm_time
 
 
-# ── xattr I/O ──────────────────────────────────────────────────────────────────
+# ── xattr I/O ─────────────────────────────────────────────────────────
 
 def read_xattr(path: str) -> bytes | None:
     """Return raw xattr bytes, or None if the attribute doesn't exist."""
@@ -104,14 +102,14 @@ def read_xattr(path: str) -> bytes | None:
 
 
 def write_xattr(path: str, raw: bytes) -> None:
-    """Write raw bytes to the xattr, with a helpful error for unsupported fs."""
+    """Write raw bytes to the xattr, ignore error."""
     try:
         os.setxattr(path, XATTR_NAME, raw)
-    except OSError as exc:
+    except OSError:
         pass
 
 
-# ── main logic ─────────────────────────────────────────────────────────────────
+# ── main logic ────────────────────────────────────────────────────────
 
 def xrd_get_size_and_adler32(path: str) -> tuple[int, int]:
     """
@@ -120,11 +118,11 @@ def xrd_get_size_and_adler32(path: str) -> tuple[int, int]:
     Reads from the xattr cache when possible; recomputes and updates
     the cache when the file has been modified or the xattr is absent.
     """
-    stat    = os.stat(path)
-    size    = stat.st_size
-    mtime   = int(stat.st_mtime)
+    stat = os.stat(path)
+    size = stat.st_size
+    mtime = int(stat.st_mtime)
 
-    # ── try to read cached value ───────────────────────────────────────────────
+    # ── try to read cached value ──────────────────────────────────────
     raw = read_xattr(path)
     if raw is not None:
         try:
@@ -132,15 +130,15 @@ def xrd_get_size_and_adler32(path: str) -> tuple[int, int]:
             if fm_time == mtime:
                 return size, f'{checksum:08x}'
         except ValueError:
-           pass   # treat corrupt xattr as missing
+            pass   # treat corrupt xattr as missing
 
-    # ── (re)compute and cache ──────────────────────────────────────────────────
+    # ── (re)compute and cache ─────────────────────────────────────────
     checksum = compute_adler32(path)
     write_xattr(path, pack_xrdcks(checksum, mtime))
     return size, f'{checksum:08x}'
 
 
-# ── CLI ────────────────────────────────────────────────────────────────────────
+# ── CLI ───────────────────────────────────────────────────────────────
 
 def main() -> None:
     if len(sys.argv) < 2:


### PR DESCRIPTION
1. xrdadler32 will read and save adler32 checksum to extend attrbute, identical to what Xrootd does.
2. use xrdadler32 to hand checksum in register-release.dp1.py
3. major bug fix in register-release.dp1.py: all attaching DIDs to datasets will happen after replicas of DIDs have been added to Rucio